### PR TITLE
Fix: u64 field size mismatch in cached ledger object getter

### DIFF
--- a/xrpl-wasm-std/src/core/ledger_objects/mod.rs
+++ b/xrpl-wasm-std/src/core/ledger_objects/mod.rs
@@ -460,7 +460,7 @@ pub mod ledger_object {
 
         let result_code = unsafe { get_ledger_obj_field(register_num, field_code, value_ptr, 8) };
 
-        match_result_code_with_expected_bytes_optional(result_code, 4, || Some(value))
+        match_result_code_with_expected_bytes_optional(result_code, 8, || Some(value))
     }
 
     #[inline]


### PR DESCRIPTION
## High Level Overview of Change

Fixes a bug where `ledger_object::get_u64_field_optional()` checks for 4 bytes instead of 8, causing all u64 field reads from cached ledger objects to fail.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
-->

### Context of Change

1. **Code Comparison:** The `current_ledger_object::get_u64_field_optional()` correctly expects 8 bytes
2. **Other Analysis:** All other field getters (u16, u32, UInt128, Hash256) expect the correct byte count
3. **XRPL Spec:** UInt64 fields serialize to 8 bytes per XRPL binary format specification
4. **Rust Spec:** `u64` is 8 bytes on all platforms

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change


<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Test Plan

Please describe the tests that you ran to verify your changes. Include as much
detail as necessary so that others can repeat the same tests.
-->
Need to test the change but looking for smart-escrow-rippled.cfg config file to start local rippled. 
CI Tests can help.

<!--
## Future Tasks
For future tasks related to PR.
-->
