### PR TITLE
Updated WASM Stdlib repo URL in docs

### DIFF
--- a/docs/comprehensive-guide.md
+++ b/docs/comprehensive-guide.md
@@ -79,7 +79,7 @@ npm install
 1. **Clone the repository:**
 
    ```shell
-   git clone https://github.com/XRPLF/xrpl-wasm-stdlib.git
+   git clone https://github.com/ripple/xrpl-wasm-stdlib.git
    cd xrpl-wasm-stdlib
    ```
 


### PR DESCRIPTION
## High Level Overview of Change

Corrected "typo"in documentation URL repo installation

XRPLF --> ripple

### Context of Change

Corrected URL for to allow new developers to have the correct repo

### Type of Change

- [X ] Documentation Updates