### PR TITLE
Fix CI: host function audit and e2e-tests sockets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 # Make sure CI fails on all warnings, including Clippy lints
 env:
   RUSTFLAGS: "-Dwarnings"
-  XRPLD_DOCKER_IMAGE: rippleci/xrpld:smart_escrow_supported
+  XRPLD_DOCKER_IMAGE: rippleci/rippled:ripple__se__supported
 
 jobs:
   pre-commit:
@@ -154,7 +154,7 @@ jobs:
 
       - name: Run docker in background
         run: |
-          docker run --detach --rm -p 5005:5005 -p 6006:6006 --volume "${{ github.workspace }}/.ci-config/":"/etc/opt/ripple/" --name xrpld-service --health-cmd="xrpld server_info || exit 1" --health-interval=5s --health-retries=10 --health-timeout=2s --entrypoint bash ${{ env.XRPLD_DOCKER_IMAGE }} -c "xrpld -a"
+          docker run --detach --rm -p 5005:5005 -p 6006:6006 --volume "${{ github.workspace }}/.ci-config/":"/etc/opt/xrpld/" --name xrpld-service --health-cmd="xrpld server_info || exit 1" --health-interval=5s --health-retries=10 --health-timeout=2s --entrypoint bash ${{ env.XRPLD_DOCKER_IMAGE }} -c "xrpld -a"
 
       - name: Wait for xrpld to be healthy
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 # Make sure CI fails on all warnings, including Clippy lints
 env:
   RUSTFLAGS: "-Dwarnings"
-  XRPLD_DOCKER_IMAGE: rippleci/rippled:ripple__se__supported
+  XRPLD_DOCKER_IMAGE: rippleci/xrpld:ripple--se--supported
 
 jobs:
   pre-commit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Run docker in background
         run: |
-          docker run --detach --rm -p 5005:5005 -p 6006:6006 --volume "${{ github.workspace }}/.ci-config/":"/etc/opt/xrpld/" --name xrpld-service --health-cmd="xrpld server_info || exit 1" --health-interval=5s --health-retries=10 --health-timeout=2s --entrypoint bash ${{ env.XRPLD_DOCKER_IMAGE }} -c "xrpld -a"
+          docker run --detach --rm -p 5005:5005 -p 6006:6006 --volume "${{ github.workspace }}/.ci-config/":"/etc/xrpld/" --name xrpld-service --health-cmd="xrpld server_info || exit 1" --health-interval=5s --health-retries=10 --health-timeout=2s --entrypoint bash ${{ env.XRPLD_DOCKER_IMAGE }} -c "xrpld -a"
 
       - name: Wait for xrpld to be healthy
         run: |

--- a/e2e-tests/float_tests/src/lib.rs
+++ b/e2e-tests/float_tests/src/lib.rs
@@ -12,7 +12,7 @@ use xrpl_wasm_stdlib::host::trace::DataRepr::AsHex;
 use xrpl_wasm_stdlib::host::trace::{DataRepr, trace, trace_data, trace_float, trace_num};
 use xrpl_wasm_stdlib::host::{
     FLOAT_ROUNDING_MODES_TO_NEAREST, cache_ledger_obj, float_add, float_compare, float_divide,
-    float_from_int, float_from_uint, float_log, float_multiply, float_pow, float_root, float_set,
+    float_from_int, float_from_mant_exp, float_from_uint, float_multiply, float_pow, float_root,
     float_subtract, get_ledger_obj_array_len, get_ledger_obj_field, get_ledger_obj_nested_field,
     trace_opaque_float,
 };
@@ -92,7 +92,9 @@ fn test_float_from_wasm() {
         let _ = trace("  float from u64 12300: failed");
     }
 
-    if 8 == unsafe { float_set(2, 123, f.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) } {
+    if 8 == unsafe {
+        float_from_mant_exp(123, 2, f.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST)
+    } {
         let _ = trace_float("  float from exp 2, mantissa 123:", &f);
     } else {
         let _ = trace("  float from exp 2, mantissa 3: failed");
@@ -229,7 +231,7 @@ fn test_float_multiply_divide() {
         };
     }
     let mut f01: [u8; 8] = [0u8; 8];
-    unsafe { float_set(-1, 1, f01.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) };
+    unsafe { float_from_mant_exp(1, -1, f01.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) };
 
     if 0 == unsafe { float_compare(f_compute.as_ptr(), 8, f01.as_ptr(), 8) } {
         let _ = trace("  repeated divide: good");
@@ -384,31 +386,6 @@ fn test_float_root() {
     let _ = trace_float("  float 6th root of 1000000:", &f_compute);
 }
 
-fn test_float_log() {
-    let _ = trace("\n$$$ test_float_log $$$");
-
-    let mut f1000000: [u8; 8] = [0u8; 8];
-    unsafe {
-        float_from_int(
-            1000000,
-            f1000000.as_mut_ptr(),
-            8,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
-        )
-    };
-    let mut f_compute: [u8; 8] = [0u8; 8];
-    unsafe {
-        float_log(
-            f1000000.as_ptr(),
-            8,
-            f_compute.as_mut_ptr(),
-            8,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
-        )
-    };
-    let _ = trace_float("  log_10 of 1000000:", &f_compute);
-}
-
 fn test_float_negate() {
     let _ = trace("\n$$$ test_float_negate $$$");
 
@@ -498,7 +475,6 @@ pub extern "C" fn finish() -> i32 {
     test_float_multiply_divide();
     test_float_pow();
     test_float_root();
-    test_float_log();
     test_float_negate();
     test_float_invert();
 

--- a/xrpl-wasm-stdlib/src/host/host_bindings_empty.rs
+++ b/xrpl-wasm-stdlib/src/host/host_bindings_empty.rs
@@ -144,7 +144,11 @@ export_host_functions! {
     // Host Function Category: FLOAT
     fn float_from_int(_in_int: i64, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
     fn float_from_uint(_in_uint_ptr: *const u8, _in_uint_len: usize, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
-    fn float_set(_exponent: i32, _mantissa: i64, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
+    fn float_from_mant_exp(_mantissa: i64, _exponent: i32, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
+    fn float_from_stamount(_in_buff: *const u8, _in_buff_len: usize, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
+    fn float_from_stnumber(_in_buff: *const u8, _in_buff_len: usize, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
+    fn float_to_int(_in_buff: *const u8, _in_buff_len: usize, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
+    fn float_to_mant_exp(_in_buff: *const u8, _in_buff_len: usize, _mant_buff: *mut u8, _mant_buff_len: usize, _exp_buff: *mut u8, _exp_buff_len: usize) -> i32;
     fn float_compare(_in_buff1: *const u8, _in_buff1_len: usize, _in_buff2: *const u8, _in_buff2_len: usize) -> i32;
     fn float_add(_in_buff1: *const u8, _in_buff1_len: usize, _in_buff2: *const u8, _in_buff2_len: usize, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
     fn float_subtract(_in_buff1: *const u8, _in_buff1_len: usize, _in_buff2: *const u8, _in_buff2_len: usize, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
@@ -152,7 +156,6 @@ export_host_functions! {
     fn float_divide(_in_buff1: *const u8, _in_buff1_len: usize, _in_buff2: *const u8, _in_buff2_len: usize, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
     fn float_pow(_in_buff: *const u8, _in_buff_len: usize, _pow: i32, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
     fn float_root(_in_buff: *const u8, _in_buff_len: usize, _root: i32, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
-    fn float_log(_in_buff: *const u8, _in_buff_len: usize, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
 
     // Host Function Category: TRACE
     fn trace(_msg_read_ptr: *const u8, _msg_read_len: usize, _data_read_ptr: *const u8, _data_read_len: usize, _as_hex: i32) -> i32;

--- a/xrpl-wasm-stdlib/src/host/host_bindings_test.rs
+++ b/xrpl-wasm-stdlib/src/host/host_bindings_test.rs
@@ -129,8 +129,16 @@ fn create_default_mock() -> MockHostBindings {
         .returning(|_, _, out_buff_len, _| out_buff_len as i32);
     mock.expect_float_from_uint()
         .returning(|_, _, _, out_buff_len, _| out_buff_len as i32);
-    mock.expect_float_set()
+    mock.expect_float_from_mant_exp()
         .returning(|_, _, _, out_buff_len, _| out_buff_len as i32);
+    mock.expect_float_from_stamount()
+        .returning(|_, _, _, out_buff_len, _| out_buff_len as i32);
+    mock.expect_float_from_stnumber()
+        .returning(|_, _, _, out_buff_len, _| out_buff_len as i32);
+    mock.expect_float_to_int()
+        .returning(|_, _, _, out_buff_len, _| out_buff_len as i32);
+    mock.expect_float_to_mant_exp()
+        .returning(|_, _, _, _, _, exp_buff_len| exp_buff_len as i32);
     mock.expect_float_compare().returning(|_, _, _, _| 0);
     mock.expect_float_add()
         .returning(|_, _, _, _, _, out_buff_len, _| out_buff_len as i32);
@@ -144,8 +152,6 @@ fn create_default_mock() -> MockHostBindings {
         .returning(|_, _, _, _, out_buff_len, _| out_buff_len as i32);
     mock.expect_float_root()
         .returning(|_, _, _, _, out_buff_len, _| out_buff_len as i32);
-    mock.expect_float_log()
-        .returning(|_, _, _, out_buff_len, _| out_buff_len as i32);
 
     // Helper to calculate sum of two lengths, clamping to i32::MAX
     let sum_lengths = |len1: usize, len2: usize| -> i32 {
@@ -276,7 +282,11 @@ export_host_functions! {
     // Host Function Category: FLOAT
     fn float_from_int(in_int: i64, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
     fn float_from_uint(in_uint_ptr: *const u8, in_uint_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
-    fn float_set(exponent: i32, mantissa: i64, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
+    fn float_from_mant_exp(mantissa: i64, exponent: i32, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
+    fn float_from_stamount(in_buff: *const u8, in_buff_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
+    fn float_from_stnumber(in_buff: *const u8, in_buff_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
+    fn float_to_int(in_buff: *const u8, in_buff_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
+    fn float_to_mant_exp(in_buff: *const u8, in_buff_len: usize, mant_buff: *mut u8, mant_buff_len: usize, exp_buff: *mut u8, exp_buff_len: usize) -> i32;
     fn float_compare(in_buff1: *const u8, in_buff1_len: usize, in_buff2: *const u8, in_buff2_len: usize) -> i32;
     fn float_add(in_buff1: *const u8, in_buff1_len: usize, in_buff2: *const u8, in_buff2_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
     fn float_subtract(in_buff1: *const u8, in_buff1_len: usize, in_buff2: *const u8, in_buff2_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
@@ -284,7 +294,6 @@ export_host_functions! {
     fn float_divide(in_buff1: *const u8, in_buff1_len: usize, in_buff2: *const u8, in_buff2_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
     fn float_pow(in_buff: *const u8, in_buff_len: usize, pow: i32, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
     fn float_root(in_buff: *const u8, in_buff_len: usize, root: i32, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
-    fn float_log(in_buff: *const u8, in_buff_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
 
     // Host Function Category: TRACE
     fn trace(msg_read_ptr: *const u8, msg_read_len: usize, data_read_ptr: *const u8, data_read_len: usize, as_hex: i32) -> i32;

--- a/xrpl-wasm-stdlib/src/host/host_bindings_trait.rs
+++ b/xrpl-wasm-stdlib/src/host/host_bindings_trait.rs
@@ -1239,10 +1239,10 @@ pub trait HostBindings {
         rounding_mode: i32,
     ) -> i32;
 
-    /// Creates a float from explicit exponent and mantissa values
+    /// Creates a float from explicit mantissa and exponent values
     /// # Parameters
-    /// * `exponent` - The exponent value
     /// * `mantissa` - The mantissa value
+    /// * `exponent` - The exponent value
     /// * `out_buff` - Pointer to output buffer where the float will be written
     /// * `out_buff_len` - The length of the output buffer in bytes
     /// * `rounding_mode` - Rounding mode to use for the operation
@@ -1251,13 +1251,99 @@ pub trait HostBindings {
     ///
     /// # Safety
     /// Caller must ensure all pointer parameters point to valid memory
-    unsafe fn float_set(
+    unsafe fn float_from_mant_exp(
         &self,
-        exponent: i32,
         mantissa: i64,
+        exponent: i32,
         out_buff: *mut u8,
         out_buff_len: usize,
         rounding_mode: i32,
+    ) -> i32;
+
+    /// Creates a float from an STAmount serialized value
+    /// # Parameters
+    /// * `in_buff` - Pointer to input STAmount buffer
+    /// * `in_buff_len` - The length of the input buffer in bytes
+    /// * `out_buff` - Pointer to output buffer where the float will be written
+    /// * `out_buff_len` - The length of the output buffer in bytes
+    /// * `rounding_mode` - Rounding mode to use for the operation
+    /// # Returns
+    /// 8 on success, error code otherwise
+    ///
+    /// # Safety
+    /// Caller must ensure all pointer parameters point to valid memory
+    unsafe fn float_from_stamount(
+        &self,
+        in_buff: *const u8,
+        in_buff_len: usize,
+        out_buff: *mut u8,
+        out_buff_len: usize,
+        rounding_mode: i32,
+    ) -> i32;
+
+    /// Creates a float from an STNumber serialized value
+    /// # Parameters
+    /// * `in_buff` - Pointer to input STNumber buffer
+    /// * `in_buff_len` - The length of the input buffer in bytes
+    /// * `out_buff` - Pointer to output buffer where the float will be written
+    /// * `out_buff_len` - The length of the output buffer in bytes
+    /// * `rounding_mode` - Rounding mode to use for the operation
+    /// # Returns
+    /// 8 on success, error code otherwise
+    ///
+    /// # Safety
+    /// Caller must ensure all pointer parameters point to valid memory
+    unsafe fn float_from_stnumber(
+        &self,
+        in_buff: *const u8,
+        in_buff_len: usize,
+        out_buff: *mut u8,
+        out_buff_len: usize,
+        rounding_mode: i32,
+    ) -> i32;
+
+    /// Converts a float to a signed integer
+    /// # Parameters
+    /// * `in_buff` - Pointer to input float value
+    /// * `in_buff_len` - The length of the input float value in bytes
+    /// * `out_buff` - Pointer to output buffer where the integer will be written
+    /// * `out_buff_len` - The length of the output buffer in bytes
+    /// * `rounding_mode` - Rounding mode to use for the operation
+    /// # Returns
+    /// 8 on success, error code otherwise
+    ///
+    /// # Safety
+    /// Caller must ensure all pointer parameters point to valid memory
+    unsafe fn float_to_int(
+        &self,
+        in_buff: *const u8,
+        in_buff_len: usize,
+        out_buff: *mut u8,
+        out_buff_len: usize,
+        rounding_mode: i32,
+    ) -> i32;
+
+    /// Decomposes a float into its mantissa and exponent components
+    /// # Parameters
+    /// * `in_buff` - Pointer to input float value
+    /// * `in_buff_len` - The length of the input float value in bytes
+    /// * `mant_buff` - Pointer to output buffer where the mantissa will be written
+    /// * `mant_buff_len` - The length of the mantissa output buffer in bytes
+    /// * `exp_buff` - Pointer to output buffer where the exponent will be written
+    /// * `exp_buff_len` - The length of the exponent output buffer in bytes
+    /// # Returns
+    /// 8 on success, error code otherwise
+    ///
+    /// # Safety
+    /// Caller must ensure all pointer parameters point to valid memory
+    unsafe fn float_to_mant_exp(
+        &self,
+        in_buff: *const u8,
+        in_buff_len: usize,
+        mant_buff: *mut u8,
+        mant_buff_len: usize,
+        exp_buff: *mut u8,
+        exp_buff_len: usize,
     ) -> i32;
 
     /// Compares two opaque float values
@@ -1424,27 +1510,6 @@ pub trait HostBindings {
         in_buff: *const u8,
         in_buff_len: usize,
         root: i32,
-        out_buff: *mut u8,
-        out_buff_len: usize,
-        rounding_mode: i32,
-    ) -> i32;
-
-    /// Calculates the natural logarithm of an opaque float value
-    /// # Parameters
-    /// * `in_buff` - Pointer to input float value
-    /// * `in_buff_len` - The length of the input float value in bytes
-    /// * `out_buff` - Pointer to output buffer where result will be written
-    /// * `out_buff_len` - The length of the output buffer in bytes
-    /// * `rounding_mode` - Rounding mode to use for the operation
-    /// # Returns
-    /// 8 on success, error code otherwise
-    ///
-    /// # Safety
-    /// Caller must ensure all pointer parameters point to valid memory
-    unsafe fn float_log(
-        &self,
-        in_buff: *const u8,
-        in_buff_len: usize,
         out_buff: *mut u8,
         out_buff_len: usize,
         rounding_mode: i32,

--- a/xrpl-wasm-stdlib/src/host/host_bindings_wasm.rs
+++ b/xrpl-wasm-stdlib/src/host/host_bindings_wasm.rs
@@ -274,12 +274,41 @@ mod host_defined_functions {
             out_buff_len: usize,
             rounding_mode: i32,
         ) -> i32;
-        pub(super) fn float_set(
-            exponent: i32,
+        pub(super) fn float_from_mant_exp(
             mantissa: i64,
+            exponent: i32,
             out_buff: *mut u8,
             out_buff_len: usize,
             rounding_mode: i32,
+        ) -> i32;
+        pub(super) fn float_from_stamount(
+            in_buff: *const u8,
+            in_buff_len: usize,
+            out_buff: *mut u8,
+            out_buff_len: usize,
+            rounding_mode: i32,
+        ) -> i32;
+        pub(super) fn float_from_stnumber(
+            in_buff: *const u8,
+            in_buff_len: usize,
+            out_buff: *mut u8,
+            out_buff_len: usize,
+            rounding_mode: i32,
+        ) -> i32;
+        pub(super) fn float_to_int(
+            in_buff: *const u8,
+            in_buff_len: usize,
+            out_buff: *mut u8,
+            out_buff_len: usize,
+            rounding_mode: i32,
+        ) -> i32;
+        pub(super) fn float_to_mant_exp(
+            in_buff: *const u8,
+            in_buff_len: usize,
+            mant_buff: *mut u8,
+            mant_buff_len: usize,
+            exp_buff: *mut u8,
+            exp_buff_len: usize,
         ) -> i32;
         pub(super) fn float_compare(
             in_buff1: *const u8,
@@ -335,13 +364,6 @@ mod host_defined_functions {
             in_buff: *const u8,
             in_buff_len: usize,
             root: i32,
-            out_buff: *mut u8,
-            out_buff_len: usize,
-            rounding_mode: i32,
-        ) -> i32;
-        pub(super) fn float_log(
-            in_buff: *const u8,
-            in_buff_len: usize,
             out_buff: *mut u8,
             out_buff_len: usize,
             rounding_mode: i32,
@@ -1085,21 +1107,99 @@ impl HostBindings for WasmHostBindings {
         }
     }
 
-    unsafe fn float_set(
+    unsafe fn float_from_mant_exp(
         &self,
-        exponent: i32,
         mantissa: i64,
+        exponent: i32,
         out_buff: *mut u8,
         out_buff_len: usize,
         rounding_mode: i32,
     ) -> i32 {
         unsafe {
-            host_defined_functions::float_set(
-                exponent,
+            host_defined_functions::float_from_mant_exp(
                 mantissa,
+                exponent,
                 out_buff,
                 out_buff_len,
                 rounding_mode,
+            )
+        }
+    }
+
+    unsafe fn float_from_stamount(
+        &self,
+        in_buff: *const u8,
+        in_buff_len: usize,
+        out_buff: *mut u8,
+        out_buff_len: usize,
+        rounding_mode: i32,
+    ) -> i32 {
+        unsafe {
+            host_defined_functions::float_from_stamount(
+                in_buff,
+                in_buff_len,
+                out_buff,
+                out_buff_len,
+                rounding_mode,
+            )
+        }
+    }
+
+    unsafe fn float_from_stnumber(
+        &self,
+        in_buff: *const u8,
+        in_buff_len: usize,
+        out_buff: *mut u8,
+        out_buff_len: usize,
+        rounding_mode: i32,
+    ) -> i32 {
+        unsafe {
+            host_defined_functions::float_from_stnumber(
+                in_buff,
+                in_buff_len,
+                out_buff,
+                out_buff_len,
+                rounding_mode,
+            )
+        }
+    }
+
+    unsafe fn float_to_int(
+        &self,
+        in_buff: *const u8,
+        in_buff_len: usize,
+        out_buff: *mut u8,
+        out_buff_len: usize,
+        rounding_mode: i32,
+    ) -> i32 {
+        unsafe {
+            host_defined_functions::float_to_int(
+                in_buff,
+                in_buff_len,
+                out_buff,
+                out_buff_len,
+                rounding_mode,
+            )
+        }
+    }
+
+    unsafe fn float_to_mant_exp(
+        &self,
+        in_buff: *const u8,
+        in_buff_len: usize,
+        mant_buff: *mut u8,
+        mant_buff_len: usize,
+        exp_buff: *mut u8,
+        exp_buff_len: usize,
+    ) -> i32 {
+        unsafe {
+            host_defined_functions::float_to_mant_exp(
+                in_buff,
+                in_buff_len,
+                mant_buff,
+                mant_buff_len,
+                exp_buff,
+                exp_buff_len,
             )
         }
     }
@@ -1243,25 +1343,6 @@ impl HostBindings for WasmHostBindings {
                 in_buff,
                 in_buff_len,
                 root,
-                out_buff,
-                out_buff_len,
-                rounding_mode,
-            )
-        }
-    }
-
-    unsafe fn float_log(
-        &self,
-        in_buff: *const u8,
-        in_buff_len: usize,
-        out_buff: *mut u8,
-        out_buff_len: usize,
-        rounding_mode: i32,
-    ) -> i32 {
-        unsafe {
-            host_defined_functions::float_log(
-                in_buff,
-                in_buff_len,
                 out_buff,
                 out_buff_len,
                 rounding_mode,
@@ -1416,7 +1497,11 @@ export_host_functions! {
     // Host Function Category: FLOAT
     fn float_from_int(in_int: i64, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
     fn float_from_uint(in_uint_ptr: *const u8, in_uint_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
-    fn float_set(exponent: i32, mantissa: i64, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
+    fn float_from_mant_exp(mantissa: i64, exponent: i32, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
+    fn float_from_stamount(in_buff: *const u8, in_buff_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
+    fn float_from_stnumber(in_buff: *const u8, in_buff_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
+    fn float_to_int(in_buff: *const u8, in_buff_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
+    fn float_to_mant_exp(in_buff: *const u8, in_buff_len: usize, mant_buff: *mut u8, mant_buff_len: usize, exp_buff: *mut u8, exp_buff_len: usize) -> i32;
     fn float_compare(in_buff1: *const u8, in_buff1_len: usize, in_buff2: *const u8, in_buff2_len: usize) -> i32;
     fn float_add(in_buff1: *const u8, in_buff1_len: usize, in_buff2: *const u8, in_buff2_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
     fn float_subtract(in_buff1: *const u8, in_buff1_len: usize, in_buff2: *const u8, in_buff2_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
@@ -1424,7 +1509,6 @@ export_host_functions! {
     fn float_divide(in_buff1: *const u8, in_buff1_len: usize, in_buff2: *const u8, in_buff2_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
     fn float_pow(in_buff: *const u8, in_buff_len: usize, pow: i32, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
     fn float_root(in_buff: *const u8, in_buff_len: usize, root: i32, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
-    fn float_log(in_buff: *const u8, in_buff_len: usize, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
 
     // Host Function Category: TRACE
     fn trace(msg_read_ptr: *const u8, msg_read_len: usize, data_read_ptr: *const u8, data_read_len: usize, as_hex: i32) -> i32;

--- a/xrpl-wasm-stdlib/src/host/mod.rs
+++ b/xrpl-wasm-stdlib/src/host/mod.rs
@@ -8,10 +8,11 @@
 //! The host provides float arithmetic functions for XRPL's fungible token amounts.
 //! These operations use rippled's Number class via FFI to ensure exact consensus compatibility:
 //!
-//! - `float_from_int` / `float_from_uint` - Convert integers to float format
-//! - `float_set` - Create float from exponent and mantissa
+//! - `float_from_int` / `float_from_uint` / `float_from_mant_exp` - Convert values to float format
+//! - `float_from_stamount` / `float_from_stnumber` - Convert XRP ledger types to float format
+//! - `float_to_int` / `float_to_mant_exp` - Convert float to integer or decomposed form
 //! - `float_add` / `float_subtract` / `float_multiply` / `float_divide` - Arithmetic
-//! - `float_pow` / `float_root` / `float_log` - Mathematical functions
+//! - `float_pow` / `float_root` - Mathematical functions
 //! - `float_compare` - Comparison operations
 //!
 //! All operations support explicit rounding modes (0=ToNearest, 1=TowardsZero, 2=Downward, 3=Upward).


### PR DESCRIPTION
## High Level Overview of Change

Removes the following host functions from wasm-stdlib:
float_log
float_set
Adds the following host functions from rippled/wasmi_host_functions to wasm-stdlib:
float_from_mant_exp
float_from_stamount
float_from_stnumber
float_to_int
float_to_mant_exp

Updates the docker volume mount from /etc/opt/ripple/ to /etc/opt/xrpld/ and docker container name

### Context of Change

Fixes CI by matching with wasmi_host_functions branch

### Type of Change



- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release


