### PR TITLE
ci: Add conventional commit setup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,22 @@
+<!--
+This PR template helps you to write a good pull request description.
+Please feel free to include additional useful information even beyond what is requested below.
+
+The PR title must follow the Conventional Commits format:
+  <type>: <Description>
+
+The description must start with a capital letter.
+Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, release, example.
+See CONTRIBUTING.md for details.
+-->
+
 ## High Level Overview of Change
 
 <!--
-Please include a summary/list of the changes.
+Please include a summary of the changes.
+This may be a direct input to the release notes.
 If too broad, please consider splitting into multiple PRs.
+If there is a relevant task or issue, please link it here.
 -->
 
 ### Context of Change
@@ -19,22 +33,22 @@ If there is a design document for this feature, please link it here.
 ### Type of Change
 
 <!--
-Please check relevant options, delete irrelevant ones.
+Please check [x] relevant options, delete irrelevant ones.
 -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactor (non-breaking change that only restructures code)
-- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
-- [ ] Documentation Updates
+- [ ] Tests (added tests for existing code, or tests for the new feature in this PR)
+- [ ] Documentation update
+- [ ] Build / CI / tooling change
 - [ ] Release
 
 <!--
 ## Test Plan
-
-Please describe the tests that you ran to verify your changes. Include as much
-detail as necessary so that others can repeat the same tests.
+Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
+This section may not be needed if your change includes thoroughly commented unit tests.
 -->
 
 <!--

--- a/.github/scripts/check-pr-description.py
+++ b/.github/scripts/check-pr-description.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+"""
+Checks that a pull request description has been customized from the
+pull_request_template.md. Exits with code 1 if the description is empty
+or identical to the template (ignoring HTML comments and whitespace).
+
+Usage:
+    python check-pr-description.py --template-file TEMPLATE --pr-body-file BODY
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def normalize(text: str) -> str:
+    """Strip HTML comments, trim lines, and remove blank lines."""
+    # Remove HTML comments (possibly multi-line)
+    text = re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+    # Strip each line and drop empties
+    lines = [line.strip() for line in text.splitlines()]
+    lines = [line for line in lines if line]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that a PR description differs from the template."
+    )
+    parser.add_argument(
+        "--template-file",
+        type=Path,
+        required=True,
+        help="Path to the pull request template file.",
+    )
+    parser.add_argument(
+        "--pr-body-file",
+        type=Path,
+        required=True,
+        help="Path to a file containing the PR body text.",
+    )
+    args = parser.parse_args()
+
+    template_path: Path = args.template_file
+    pr_body_path: Path = args.pr_body_file
+
+    if not template_path.is_file():
+        print(f"::error::Template file {template_path} not found")
+        return 1
+
+    if not pr_body_path.is_file():
+        print(f"::error::PR body file {pr_body_path} not found")
+        return 1
+
+    template = template_path.read_text(encoding="utf-8")
+    pr_body = pr_body_path.read_text(encoding="utf-8")
+
+    # Check if the PR body is empty or whitespace-only
+    if not pr_body.strip():
+        print(
+            "::error::PR description is empty. "
+            "Please fill in the pull request template."
+        )
+        return 1
+
+    norm_template = normalize(template)
+    norm_pr_body = normalize(pr_body)
+
+    if norm_pr_body == norm_template:
+        print(
+            "::error::PR description (ignoring HTML comments) is identical"
+            " to the template. Please fill in the details of your change."
+            f"\n\nVisible template content:\n---\n{norm_template}\n---"
+            f"\n\nVisible PR description content:\n---\n{norm_pr_body}\n---"
+        )
+        return 1
+
+    print("PR description has been customized from the template.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/check-pr-commits.yml
+++ b/.github/workflows/check-pr-commits.yml
@@ -1,0 +1,13 @@
+name: Check PR commits
+
+on:
+  pull_request_target:
+
+# The action needs to have write permissions to post comments on the PR.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check_commits:
+    uses: XRPLF/actions/.github/workflows/check-pr-commits.yml@e2c7f400d1e85ae65dad552fd425169fbacca4a3

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -17,6 +17,9 @@ on:
       - "release/*"
       - "staging/*"
 
+permissions:
+  contents: read
+
 jobs:
   check_description:
     if: ${{ github.event.pull_request.draft != true }}

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -1,0 +1,39 @@
+name: Check PR description
+
+on:
+  merge_group:
+    types:
+      - checks_requested
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+      - "release-*"
+      - "release/*"
+      - "staging/*"
+
+jobs:
+  check_description:
+    if: ${{ github.event.pull_request.draft != true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Write PR body to file
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        if: ${{ github.event_name == 'pull_request' }}
+        run: printenv PR_BODY >pr_body.md
+
+      - name: Check PR description differs from template
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          python .github/scripts/check-pr-description.py \
+              --template-file .github/pull_request_template.md \
+              --pr-body-file pr_body.md

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -37,6 +37,6 @@ jobs:
       - name: Check PR description differs from template
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          python .github/scripts/check-pr-description.py \
+          python3 .github/scripts/check-pr-description.py \
               --template-file .github/pull_request_template.md \
               --pr-body-file pr_body.md

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@v7
 
       - name: Write PR body to file
         env:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,50 @@
+name: Check PR title
+
+on:
+  merge_group:
+    types:
+      - checks_requested
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+      - "release-*"
+      - "release/*"
+      - "staging/*"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check_title:
+    if: ${{ github.event.pull_request.draft != true }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1 # 1.5.2
+        # This workflow is used in both pull_request and merge_queue events.
+        # But we only want to check the title for pull requests, not for merge queue events.
+        #
+        # In merge queue events, the PR titles are already validated in individual PRs.
+        #
+        # Since the check is required, we still have to run the action, but it turns out to be no-op for merge queue events.
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          task_types: '["build", "feat", "fix", "docs", "test", "ci", "style", "refactor", "perf", "chore", "release", "example"]'
+          add_label: false
+
+      - name: Check if title starts with capital letter after prefix
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ ! "${TITLE}" =~ ^[a-z]+:\ [\[A-Z] ]]; then
+              echo "Error: Title must start with an uppercase letter after the prefix."
+              exit 1
+          fi

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   check_title:
     if: ${{ github.event.pull_request.draft != true }}

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ ! "${TITLE}" =~ ^[a-z]+:\ [\[A-Z] ]]; then
+          if [[ ! "${TITLE}" =~ ^[a-z]+:\ [A-Z] ]]; then
               echo "Error: Title must start with an uppercase letter after the prefix."
               exit 1
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Cache dependencies
         uses: actions/cache/restore@v4
         with:
@@ -39,7 +39,7 @@ jobs:
   clippy_linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Cache dependencies
         uses: actions/cache/restore@v4
         with:
@@ -57,7 +57,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Run formatting check
         run: ./scripts/fmt.sh
@@ -65,7 +65,7 @@ jobs:
   check_wasm_exports:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Check WASM contract exports
         run: ./scripts/check-wasm-exports.sh
@@ -73,7 +73,7 @@ jobs:
   host_function_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Run host function audit
         run: ./scripts/host-function-audit.sh
@@ -81,7 +81,7 @@ jobs:
   validate_ui:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Validate UI
         run: ./scripts/validate-ui.sh
@@ -89,7 +89,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -108,7 +108,7 @@ jobs:
   run-markdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Run code in Markdown files
         run: ./scripts/run-markdown.sh
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_and_test
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Use Node.js v24
         uses: actions/setup-node@v4
@@ -184,7 +184,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Cache dependencies
         uses: actions/cache/restore@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,48 @@
 - Follow general code style guidelines (enforced by CI) and [naming conventions](./docs/NAMING_CONVENTIONS.md).
 - Include tests for new functionality
 - Update documentation as needed
+- Use a Conventional Commits PR title (see below) and a non-empty description filled in from the PR template
+
+### Conventional Commits
+
+PR titles are checked in CI and must follow this format:
+
+```
+<type>: <Description>
+```
+
+- `<type>` is one of the allowed types in the table below, all lowercase.
+- The description must start with a capital letter.
+- Keep the title short and imperative (e.g. "Add typed AMM accessor", not "Added typed AMM accessor").
+
+Allowed types:
+
+| Type       | Use for                                                          |
+| ---------- | ---------------------------------------------------------------- |
+| `feat`     | A new feature (host function, helper, public API addition, etc.) |
+| `fix`      | A bug fix                                                        |
+| `docs`     | Documentation-only changes                                       |
+| `style`    | Formatting, missing semicolons, etc.; no code behavior change    |
+| `refactor` | Code change that neither fixes a bug nor adds a feature          |
+| `perf`     | Performance improvement                                          |
+| `test`     | Adding or correcting tests                                       |
+| `build`    | Build system, Cargo, toolchain, or dependency changes            |
+| `ci`       | CI configuration and workflow changes                            |
+| `chore`    | Maintenance that doesn't fit the categories above                |
+| `release`  | Release-related changes (version bumps, changelog updates, etc.) |
+| `example`  | Adding or changing a sample contract under `examples/`           |
+
+Examples:
+
+- `feat: Add typed accessor for AMM ledger object`
+- `fix: Correct return code for missing keylet`
+- `docs: Document hello_world build steps`
+- `ci: Enforce conventional commit PR titles`
+- `example: Add freelancer escrow sample`
+
+When a PR is merged with squash-and-merge, the PR title becomes the commit message — keeping titles in this format keeps `git log` on `main` clean and machine-readable.
+
+When merging without squashing, individual commits are also checked; commits that do not follow the format will be flagged by the `Check PR commits` workflow.
 
 **For new examples:**
 


### PR DESCRIPTION
## High Level Overview of Change

This PR adds a few extra CI checks:
* Checking for conventional commits
* Checking for a proper PR description
* Checking for signed commits

This is copied from the rippled setup and adapted to this repo as needed.

### Context of Change

Improving repo management

### Type of Change

- [x] CI